### PR TITLE
add python-sdk.flow.arcalot.io alias

### DIFF
--- a/dns_records.yaml
+++ b/dns_records.yaml
@@ -31,6 +31,11 @@ request:
       rrset_values:
         - "arcalot.github.io."
       rrset_ttl: 3600
+    - rrset_name: "python-sdk.flow"
+      rrset_type: "CNAME"
+      rrset_values:
+        - "readthedocs.io."
+      rrset_ttl: 3600
     - rrset_name: "gm1._domainkey"
       rrset_type: "CNAME"
       rrset_values:


### PR DESCRIPTION
## Changes introduced with this PR

Adding python-sdk.flow.arcalot.io alias for readthedocs.io.

Related-To: https://github.com/arcalot/arcaflow-plugin-sdk-python/issues/53
Signed-off-by: Sandro Bonazzola <sbonazzo@redhat.com>

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).