### PR TITLE
Pass permissions to workflow

### DIFF
--- a/.github/workflows/update_dns.yml
+++ b/.github/workflows/update_dns.yml
@@ -22,6 +22,9 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/heads/main')
     needs: ["build"]
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Check out code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Changes introduced with this PR

This may need to be done similar to docsgen to allow permissions to be passed to the workflow.
We changed this organization wide a couple months ago to not allow blanket permissions to workflow to write access. This particular build workflow has not ran in over a year. I suspect this may be the culprit. Worth a check

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).