### PR TITLE
Renovate/auto merged updates

### DIFF
--- a/.github/workflows/update_dns.yml
+++ b/.github/workflows/update_dns.yml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
+        uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
       - name: Install dependencies
@@ -27,9 +27,9 @@ jobs:
       pull-requests: write
     steps:
       - name: Check out code
-        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
+        uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
       - name: Install dependencies

--- a/.github/workflows/update_dns.yml
+++ b/.github/workflows/update_dns.yml
@@ -17,32 +17,12 @@ jobs:
         run: pip install -r requirements.txt
       - name: Run tests
         run: python -m unittest discover
-  update:
-    name: Run DNS update
-    runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/heads/main')
-    needs: ["build"]
-    permissions:
-      contents: write
-      pull-requests: write
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: 3.9
-      - name: Install dependencies
-        run: pip install -r requirements.txt
-      - name: Replace API key
-        run: |
-          sed -i -e 's/API_KEY/${{ secrets.GANDI_API_KEY }}/' dns_records.yaml
       - name: DNS update
+        if: startsWith(github.ref, 'refs/heads/main')
         run: |
           set -e
+          sed -i -e 's/API_KEY/${{ secrets.GANDI_API_KEY }}/' dns_records.yaml
           ./gandi_dns_plugin.py -f dns_records.yaml | tee /tmp/response.yaml
-          if [ $(cat /tmp/response.yaml | grep 'output_id: success' | wc -l) -ne 1 ]; then
-            rm -rf /tmp/response.yaml
-            exit 1
-          fi
+          grep -q 'output_id: success' /tmp/response.yaml && rc=$? || rc=$?
           rm -rf /tmp/response.yaml
+          exit $rc


### PR DESCRIPTION
## Changes introduced with this PR

This PR modifies the branch for #15:  the Renovate bot is proposing that we update the digest hashes for the `checkout` GitHub Action.  This PR replaces the digests with semantic version tags, so that we can follow such updates implicitly, without having to modify our files (and without the noise of such PRs).

This PR also reworks the workflow somewhat:
- Combine the two jobs to avoid repeating steps
- Roll the "Replace API key" step into the subsequent step
- Make the subsequent step conditional (instead of the whole job)
- Simplify the error handling

The second job is executed conditionally, only for pushes to the `main` branch; however, the two jobs use the same setup, and the second job is dependent upon the first, so it would be better to run the second job as an additional `step` in the first.  I think the principal reason for the present structure is to enable the conditionalization, but conditionalization is available on `step`'s as well as `job`'s, so that's not a requirement; also, the second job was granted additional permissions, but I don't think those are required, so I've removed them as well.

Beyond that, I've combined the steps from the second job together and simplified the error handling.

[FWIW, I seem to have limited access to this repo; if one of the Gods of Arca were so inclined, I would appreciate being able to push commits to the upstream repo, so that I can modify the Renovate bot's branches directly...thanks!]

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).